### PR TITLE
Add support for TLS snap configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,12 +113,13 @@ and OVN:
 * `network.ovn-sb-connection` (`tcp:127.0.0.1:6642`) OVN Southbound DB connection URL
 * `network.enable-gateway` (False) Enable OVS/OVS as north/south gateway
 
-If OVN is configured to use TLS for security, certificates and keys should
-be placed in the following locations:
+TLS configuration for OVN can also be supplied via snap configuration:
 
-* `$SNAP_COMMON/etc/ssl/certs/ovn-cacert.pem`: CA certificate of authority that signed certificate below.
-* `$SNAP_COMMON/etc/ssl/certs/ovn-cert.pem`: Certificate for local OVN client access
-* `$SNAP_COMMON/etc/ssl/private/ovn-key.pem`: Private key for local OVN client access
+* `network.ovn-key` Private TLS key
+* `network.ovn-cert` TLS certificate for `ovn-key`
+* `network.ovn-cacert` CA certificate (and chain) for certificate validation
+
+All of the above options must be provided as base64 encoded strings.
 
 ### rabbitmq
 

--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -36,7 +36,7 @@ MAPPING = {
 
 @app.get("/")
 async def root():
-    """Handles requests to the root URL
+    """Handles requests to the root URL.
 
     :return:
     """
@@ -45,7 +45,7 @@ async def root():
 
 @app.get("/settings")
 async def settings():
-    """Handle requests for settings
+    """Handle requests for settings.
 
     :return:
     """
@@ -70,7 +70,7 @@ async def section_settings(section: str):
 
 
 def _update_settings(section: str, config: BaseModel):
-    """Updates the snap settings
+    """Updates the snap settings.
 
     :param section:
     :param config:
@@ -89,29 +89,35 @@ def _update_settings(section: str, config: BaseModel):
 
 @app.patch("/settings/identity")
 async def update_identity(config: model.IdentityServiceConfig):
+    """Updates identity section settings."""
     return _update_settings("identity", config)
 
 
 @app.patch("/settings/network")
 async def update_network(config: model.NetworkConfig):
+    """Updates network section settings."""
     return _update_settings("network", config)
 
 
 @app.patch("/settings/rabbitmq")
 async def update_rabbitmq(config: model.RabbitMQConfig):
+    """Updates rabbitmq section settings."""
     return _update_settings("rabbitmq", config)
 
 
 @app.patch("/settings/compute")
 async def update_compute(config: model.ComputeConfig):
+    """Updates compute section settings."""
     return _update_settings("compute", config)
 
 
 @app.patch("/settings/node")
 async def update_node(config: model.NodeConfig):
+    """Updates node section settings."""
     return _update_settings("node", config)
 
 
 @app.patch("/settings/logging")
 async def update_logging(config: model.LoggingConfig):
+    """Updates logging section settings."""
     return _update_settings("logging", config)

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -392,11 +392,11 @@ def _configure_ovn_tls(snap: Snap) -> None:
     ssl_cert = snap.paths.common / Path("etc/ssl/certs/ovn-cert.pem")
     ssl_cacert = snap.paths.common / Path("etc/ssl/certs/ovn-cacert.pem")
 
-    with open(ssl_key, "w") as f:
+    with open(ssl_key, "wb") as f:
         f.write(ovn_key)
-    with open(ssl_cert, "w") as f:
+    with open(ssl_cert, "wb") as f:
         f.write(ovn_cert)
-    with open(ssl_cacert, "w") as f:
+    with open(ssl_cacert, "wb") as f:
         f.write(ovn_cacert)
 
     subprocess.check_call(

--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -18,6 +18,8 @@ from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress
 
 
 class RabbitMQUrl(AnyUrl):
+    """URL model for RabbitMQ URLs."""
+
     allowed_schemes = {"rabbit", "amqp"}
     host_required = True
 
@@ -72,6 +74,9 @@ class NetworkConfig(BaseModel):
     dns_domain = Field(alias="dns-domain", default="openstack.local")
     dns_servers: IPvAnyAddress = Field(alias="dns-servers", default="8.8.8.8")
     ovn_sb_connection: str = Field(alias="ovn-sb-connection", default="tcp:127.0.0.1:6642")
+    ovn_key: Optional[str] = Field(Alias="ovn-key")
+    ovn_cert: Optional[str] = Field(Alias="ovn-cert")
+    ovn_cacert: Optional[str] = Field(Alias="ovn-cacert")
     enable_gateway: bool = Field(alias="enable-gateway", default=False)
     ip_address: Optional[IPvAnyAddress] = Field(alias="network.ip-address")
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -582,9 +582,9 @@ parts:
       - python3-systemd
       - haproxy
       - util-linux
-#    organize:
-#      usr/share/ieee-data/iab.txt: usr/lib/python3/dist-packages/netaddr/eui/iab.txt
-#      usr/share/ieee-data/oui.txt: usr/lib/python3/dist-packages/netaddr/eui/oui.txt
+    organize:
+      usr/share/ieee-data/iab.txt: usr/lib/python3/dist-packages/netaddr/eui/iab.txt
+      usr/share/ieee-data/oui.txt: usr/lib/python3/dist-packages/netaddr/eui/oui.txt
     override-build: |
       snapcraftctl build
       # NOTE:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -582,9 +582,6 @@ parts:
       - python3-systemd
       - haproxy
       - util-linux
-    organize:
-      usr/share/ieee-data/iab.txt: usr/lib/python3/dist-packages/netaddr/eui/iab.txt
-      usr/share/ieee-data/oui.txt: usr/lib/python3/dist-packages/netaddr/eui/oui.txt
     override-build: |
       snapcraftctl build
       # NOTE:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -589,6 +589,9 @@ parts:
       # conflicts with the libvirt part provided versions
       rm -rf $SNAPCRAFT_PART_INSTALL/usr/share/libvirt
       rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/*/libvirt*
+      # purge some dangling symlinks
+      rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages/netaddr/eui/iab.txt
+      rm -rf $SNAPCRAFT_PART_INSTALL/usr/lib/python3/dist-packages/netaddr/eui/oui.txt
 
   snap-hooks:
     plugin: python


### PR DESCRIPTION
Add new config keys and API model to support configuration of TLS keys and certs via the snap configuration interface.