### PR TITLE
Ensure all directories created during install

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -165,6 +165,7 @@ def install(snap: Snap) -> None:
     logging.info("Running install hook")
     logging.info(f"Setting default config: {DEFAULT_CONFIG}")
     snap.config.set(DEFAULT_CONFIG)
+    _mkdirs(snap)
 
 
 def _get_template(snap: Snap, template: str) -> Template:


### PR DESCRIPTION
The configure hook does not run until after the install hook; ensure that required runtime directories are created as part of install and configure.