### PR TITLE
Drop ovn commands for hypervisor role

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -172,19 +172,6 @@ apps:
       - network
       - network-bind
       - microstack-support
-  ovn-nbctl:
-    command: usr/bin/ovn-nbctl
-    plugs:
-      - network
-      - network-bind
-      - microstack-support
-  ovn-sbctl:
-    command: usr/bin/ovn-sbctl
-    plugs:
-      - network
-      - network-bind
-      - process-control
-      - microstack-support
 
   ovs-vsctl:
     command: usr/bin/ovs-vsctl


### PR DESCRIPTION
Operators will not need to use the ovn-{nb,sb}ctl commands on the hypervisor as this are only used in ovn-central units.