### PR TITLE
Add support to configure external bridge

### DIFF
--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress
+from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress, IPvAnyNetwork
 
 
 class RabbitMQUrl(AnyUrl):
@@ -71,6 +71,7 @@ class NetworkConfig(BaseModel):
 
     physnet_name: str = Field(alias="physnet-name", default="physnet1")
     external_bridge: str = Field(alias="external-bridge", default="br-ex")
+    external_network_cidr: Optional[IPvAnyNetwork] = Field(alias="external-network-cidr")
     dns_domain = Field(alias="dns-domain", default="openstack.local")
     dns_servers: IPvAnyAddress = Field(alias="dns-servers", default="8.8.8.8")
     ovn_sb_connection: str = Field(alias="ovn-sb-connection", default="tcp:127.0.0.1:6642")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ fastapi
 gunicorn
 netifaces
 pydantic
+pyroute2
 uvicorn[standard]

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -241,6 +241,8 @@ apps:
     plugs:
       - network
       - network-bind
+      - network-control
+      - firewall-control
       - microstack-support
     install-mode: enable
     sockets:
@@ -602,7 +604,11 @@ hooks:
   install:
     plugs: [ network, microstack-support]
   configure:
-    plugs: [ network, microstack-support]
+    plugs:
+      - network
+      - network-control
+      - firewall-control
+      - microstack-support
   connect-slot-hypervisor-config:
     plugs:
       - network

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -55,3 +55,26 @@ def os_makedirs():
 def check_call():
     with patch("subprocess.check_call") as p:
         yield p
+
+
+@pytest.fixture
+def link_lookup():
+    with patch("pyroute2.IPRoute.link_lookup") as p:
+        yield p
+
+
+@pytest.fixture
+def split():
+    yield "1.2.3.4/24"
+
+
+@pytest.fixture
+def addr():
+    with patch("pyroute2.IPRoute.addr") as p:
+        yield p
+
+
+@pytest.fixture
+def link():
+    with patch("pyroute2.IPRoute.link") as p:
+        yield p

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -31,7 +31,9 @@ class TestHooks:
         hooks._get_template(snap, "foo.bar")
         mock_fs_loader.assert_called_once_with(searchpath=str(snap.paths.snap / "templates"))
 
-    def test_configure_hook(self, mocker, snap, os_makedirs, check_call):
+    def test_configure_hook(
+        self, mocker, snap, os_makedirs, check_call, link_lookup, split, addr, link
+    ):
         """Tests the configure hook."""
         mock_template = mocker.Mock()
         mocker.patch.object(hooks, "_get_template", return_value=mock_template)


### PR DESCRIPTION
This patch is to configure external bridge with
proper ip address and update necessary iptables.
Also exposed the new parameter external_network_cidr via hypervisor-config api so that microstack can
send a request to update external bridge configuration.