### PR TITLE
Redux external bridge addressing

### DIFF
--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -14,7 +14,7 @@
 
 from typing import Optional
 
-from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress, IPvAnyNetwork
+from pydantic import AnyUrl, BaseModel, Field, IPvAnyAddress, IPvAnyInterface
 
 
 class RabbitMQUrl(AnyUrl):
@@ -71,7 +71,7 @@ class NetworkConfig(BaseModel):
 
     physnet_name: str = Field(alias="physnet-name", default="physnet1")
     external_bridge: str = Field(alias="external-bridge", default="br-ex")
-    external_network_cidr: Optional[IPvAnyNetwork] = Field(alias="external-network-cidr")
+    external_bridge_addresss: Optional[IPvAnyInterface] = Field(alias="external-bridge-address")
     dns_domain = Field(alias="dns-domain", default="openstack.local")
     dns_servers: IPvAnyAddress = Field(alias="dns-servers", default="8.8.8.8")
     ovn_sb_connection: str = Field(alias="ovn-sb-connection", default="tcp:127.0.0.1:6642")

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -78,3 +78,9 @@ def addr():
 def link():
     with patch("pyroute2.IPRoute.link") as p:
         yield p
+
+
+@pytest.fixture
+def ip_interface():
+    with patch("ipaddress.ip_interface") as p:
+        yield p

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -32,7 +32,7 @@ class TestHooks:
         mock_fs_loader.assert_called_once_with(searchpath=str(snap.paths.snap / "templates"))
 
     def test_configure_hook(
-        self, mocker, snap, os_makedirs, check_call, link_lookup, split, addr, link
+        self, mocker, snap, os_makedirs, check_call, link_lookup, split, addr, link, ip_interface
     ):
         """Tests the configure hook."""
         mock_template = mocker.Mock()


### PR DESCRIPTION
Switch to using a fully qualified interface definition for the external networking brigde when running in host only mode for north south traffic routing to floating IP's.