### PR TITLE
Remove pyroute2 from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+# WARNING: Please ensure that any packages listed here do not overlap with
+#          the payloads requirements.
 # for interacting with snap
 git+https://github.com/albertodonato/snap-helpers#egg=snap-helpers
 jinja2
@@ -6,5 +8,4 @@ fastapi
 gunicorn
 netifaces
 pydantic
-pyroute2
 uvicorn[standard]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+pyroute2

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,7 @@ deps =
     pytest-mock
     coverage[toml]
     -r{toxinidir}/requirements.txt
+    -r{toxinidir}/test-requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
         -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}


### PR DESCRIPTION
Neutron uses pyroute2. Having pyroute2 in the snap requirements.txt causes a version which is incompatable with Neutron to be installed.