### PR TITLE
Add /health to the api service

### DIFF
--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -43,6 +43,21 @@ async def root():
     return {"version": "0.1"}
 
 
+@app.get("/health")
+async def health():
+    """Handle requests for health status.
+
+    A dictionary is returned, the key 'ready' indicates whether the
+    hypervisor is up and functional.
+    """
+    service_status = snap.services.list()
+    health = {
+        "ready": all([v._info.active for v in service_status.values()]),
+        "service_detail": service_status,
+    }
+    return health
+
+
 @app.get("/settings")
 async def settings():
     """Handle requests for settings.

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands =
     # uncomment the following line if this charm owns a lib
     # codespell {[vars]lib_path}
     codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/venv
+      --skip {toxinidir}/./.tox --skip {toxinidir}/venv
     # pflake8 wrapper supports config from pyproject.toml
     pflake8 {[vars]src_path}
     isort --check-only --diff {[vars]src_path}


### PR DESCRIPTION
Add /health so the health of the snap can be queried via the socket. At the moment the status of the services is checked and if all are active the snap is marked as ready.