### PR TITLE
Increase gunicorn worker timeout

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -227,7 +227,7 @@ apps:
       - microstack-support
 
   hypervisor-config-service:
-    command: 'bin/gunicorn openstack_hypervisor.api:app --workers 1 --worker-class uvicorn.workers.UvicornWorker --bind unix:$SNAP_DATA/run/hypervisor-config/unix.socket'
+    command: 'bin/gunicorn openstack_hypervisor.api:app --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 120 --bind unix:$SNAP_DATA/run/hypervisor-config/unix.socket'
     restart-condition: on-failure
     daemon: simple
     slots:


### PR DESCRIPTION
Among other things the gunicorn worker manages restarting systemd services. Most of these services have TimeoutStopSec set to 30. This means that if any of the services are not responding then systemd will wait 30s for before killing the service. However the gunicorn worker also has a timeout of 30s meaning that the gunicorn worker ends up getting killed as well. This change increases the worker timeout from 30s to 2 minutes.

This situation seems to occur most often during a microstack reset. The model hosting rabbitmq is removed and the nova-compute seems to not respond to shutdown requests while reporting EHOSTUNREACH errors.