### PR TITLE
Stop setting 'unset' snap config values

### DIFF
--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -142,5 +142,9 @@ async def update_logging(config: model.LoggingConfig):
 async def reset_config():
     """Reset all configs to default."""
     config = {k: (v() if callable(v) else v) for k, v in hooks.DEFAULT_CONFIG.items()}
+    unset_keys = [k for k, v in config.items() if v == hooks.UNSET]
     snap.config.set(config)
+    # Replace with snap.config.unset when https://github.com/albertodonato/snap-helpers/pull/9
+    # lands
+    snap.config._snapctl.config_unset(*unset_keys)
     hooks.configure(snap)


### PR DESCRIPTION
The snap uses pydantic to validate data. Setting a key to have a value of UNSET ('') in some cases fails this validation. For example the rabbitmq.url value must conform to pydantic AnyURL which does not permit and empty string. To avoid this stop setting snap config values to UNSET.