### PR TITLE
Fix OVN key checks from snap db

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -193,7 +193,7 @@ REQUIRED_CONFIG = {
         "rabbitmq.url",
         "network",
     ],
-    "neutron-ovn-metadata-agent": ["credentials", "network", "node", "network.ovn-key"],
+    "neutron-ovn-metadata-agent": ["credentials", "network", "node", "network.ovn_key"],
 }
 
 

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -103,9 +103,9 @@ class TestHooks:
         ]
         config["network"] = {
             "external-bridge-address": "10.0.0.10",
-            "ovn-cert": "cert",
-            "ovn-key": "key",
-            "ovn-cacert": "cacert",
+            "ovn_cert": "cert",
+            "ovn_key": "key",
+            "ovn_cacert": "cacert",
         }
         assert hooks._services_not_ready(config) == ["neutron-ovn-metadata-agent"]
         config["credentials"] = {"ovn_metadata_proxy_shared_secret": "secret"}


### PR DESCRIPTION
The OVN keys use an underscore rather than a hyphen. This is causing the charm to incorrectly think it is missing config.