### PR TITLE
Correct catching exception when nic is configured

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -30,8 +30,8 @@ from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader, Template
 from netifaces import AF_INET, gateways, ifaddresses
+from pr2modules.netlink.exceptions import NetlinkError
 from pyroute2 import IPRoute
-from pyroute2.netlink.exceptions import NetlinkError
 from snaphelpers import Snap
 from snaphelpers._conf import UnknownConfigKey
 


### PR DESCRIPTION
If microstack is configured then refreshing the hypervisor snap fails because it tries to add an existing ip to the bridge. The code attempts to handle this situation by catching NetlinkError. However, it catches `pyroute2.netlink.exceptions.NetlinkError` but `pr2modules.netlink.exceptions.NetlinkError` is actually whats thrown:

```
error: cannot perform the following tasks:
- Run configure hook of "openstack-hypervisor" snap if present (run hook "configure":
-----
Traceback (most recent call last):
  File "/snap/openstack-hypervisor/x5/snap/hooks/configure", line 9, in <module>
    sys.exit(configure(Snap()))
  File "/snap/openstack-hypervisor/x5/lib/python3.10/site-packages/openstack_hypervisor/hooks.py", line 837, in configure
    _configure_ovn_external_networking(snap)
  File "/snap/openstack-hypervisor/x5/lib/python3.10/site-packages/openstack_hypervisor/hooks.py", line 552, in _configure_ovn_external_networking
    _add_ip_to_interface(external_bridge, external_bridge_address)
  File "/snap/openstack-hypervisor/x5/lib/python3.10/site-packages/openstack_hypervisor/hooks.py", line 358, in _add_ip_to_interface
    ipr.addr("add", index=dev, address=ip_mask[0], mask=int(ip_mask[1]))
  File "/snap/openstack-hypervisor/x5/usr/lib/python3/dist-packages/pr2modules/iproute/linux.py", line 1518, in addr
    ret = self.nlm_request(msg,
  File "/snap/openstack-hypervisor/x5/usr/lib/python3/dist-packages/pr2modules/netlink/nlsocket.py", line 393, in nlm_request
    return tuple(self._genlm_request(*argv, **kwarg))
  File "/snap/openstack-hypervisor/x5/usr/lib/python3/dist-packages/pr2modules/netlink/nlsocket.py", line 885, in nlm_request
    for msg in self.get(msg_seq=msg_seq,
  File "/snap/openstack-hypervisor/x5/usr/lib/python3/dist-packages/pr2modules/netlink/nlsocket.py", line 396, in get
    return tuple(self._genlm_get(*argv, **kwarg))
  File "/snap/openstack-hypervisor/x5/usr/lib/python3/dist-packages/pr2modules/netlink/nlsocket.py", line 721, in get
    raise msg['header']['error']
pr2modules.netlink.exceptions.NetlinkError: (17, 'File exists')
-----)
```