### PR TITLE
Manage a nic used for north/south traffic

### DIFF
--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -17,7 +17,6 @@ import json
 from fastapi import FastAPI
 from pydantic import BaseModel
 from snaphelpers import Snap
-from snaphelpers._conf import UnknownConfigKey
 
 from openstack_hypervisor import hooks, model
 
@@ -142,14 +141,6 @@ async def update_logging(config: model.LoggingConfig):
 @app.post("/reset")
 async def reset_config():
     """Reset all configs to default."""
-    try:
-        # Need to remove the nic from the bridge before the config is reset and the
-        # nic name is lost.
-        gateway_nic = snap.config.get("network.gateway-nic")
-        external_bridge = snap.config.get("network.external-bridge")
-        hooks.del_interface_from_bridge(external_bridge, gateway_nic)
-    except UnknownConfigKey:
-        pass
     config = {k: (v() if callable(v) else v) for k, v in hooks.DEFAULT_CONFIG.items()}
     unset_keys = [k for k, v in config.items() if v == hooks.UNSET]
     snap.config.set(config)

--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -17,6 +17,7 @@ import json
 from fastapi import FastAPI
 from pydantic import BaseModel
 from snaphelpers import Snap
+from snaphelpers._conf import UnknownConfigKey
 
 from openstack_hypervisor import hooks, model
 
@@ -141,6 +142,14 @@ async def update_logging(config: model.LoggingConfig):
 @app.post("/reset")
 async def reset_config():
     """Reset all configs to default."""
+    try:
+        # Need to remove the nic from the bridge before the config is reset and the
+        # nic name is lost.
+        gateway_nic = snap.config.get("network.gateway-nic")
+        external_bridge = snap.config.get("network.external-bridge")
+        hooks.del_interface_from_bridge(external_bridge, gateway_nic)
+    except UnknownConfigKey:
+        pass
     config = {k: (v() if callable(v) else v) for k, v in hooks.DEFAULT_CONFIG.items()}
     unset_keys = [k for k, v in config.items() if v == hooks.UNSET]
     snap.config.set(config)

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -584,9 +584,7 @@ def _ensure_single_nic_on_bridge(external_bridge: str, external_nic: str) -> Non
         _add_interface_to_bridge(external_bridge, external_nic)
     for p in external_ports:
         if p != external_nic:
-            logging.debug(
-                f"Removing additional extranal ports {external_ports} from {external_bridge}"
-            )
+            logging.debug(f"Removing additional external port {p} from {external_bridge}")
             _del_interface_from_bridge(external_bridge, p)
 
 

--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -174,7 +174,7 @@ DEFAULT_CONFIG = {
     "network.ovn-cacert": UNSET,
     "network.enable-gateway": False,
     "network.ip-address": _get_local_ip_by_default_route,  # noqa: F821
-    "network.gateway-nic": UNSET,
+    "network.external-nic": UNSET,
     # General
     "logging.debug": False,
     "node.fqdn": socket.getfqdn,
@@ -500,8 +500,11 @@ def _configure_ovn_base(snap: Snap) -> None:
     )
 
 
-def list_bridge_ifaces(bridge_name: str) -> list:
-    """Return a list of interfaces attached to given bridge."""
+def _list_bridge_ifaces(bridge_name: str) -> list:
+    """Return a list of interfaces attached to given bridge.
+
+    :param bridge_name: Name of bridge.
+    """
     ifaces = (
         subprocess.check_output(["ovs-vsctl", "--retry", "list-ifaces", bridge_name])
         .decode()
@@ -510,22 +513,90 @@ def list_bridge_ifaces(bridge_name: str) -> list:
     return sorted(ifaces)
 
 
-def add_interface_to_bridge(external_bridge: str, gateway_nic: str) -> None:
-    """Add an interface to a given bridge."""
-    if gateway_nic in list_bridge_ifaces(external_bridge):
-        logging.warning(f"Interface {gateway_nic} already connected to {external_bridge}")
+def _add_interface_to_bridge(external_bridge: str, external_nic: str) -> None:
+    """Add an interface to a given bridge.
+
+    :param bridge_name: Name of bridge.
+    :param external_nic: Name of nic.
+    """
+    if external_nic in _list_bridge_ifaces(external_bridge):
+        logging.warning(f"Interface {external_nic} already connected to {external_bridge}")
     else:
-        logging.warning(f"Adding interface {gateway_nic} to {external_bridge}")
-        subprocess.check_call(["ovs-vsctl", "--retry", "add-port", external_bridge, gateway_nic])
+        logging.warning(f"Adding interface {external_nic} to {external_bridge}")
+        cmd = [
+            "ovs-vsctl",
+            "--retry",
+            "add-port",
+            external_bridge,
+            external_nic,
+            "--",
+            "set",
+            "Port",
+            external_nic,
+            "external-ids:microstack-function=ext-port",
+        ]
+        subprocess.check_call(cmd)
 
 
-def del_interface_from_bridge(external_bridge: str, gateway_nic: str) -> None:
-    """Remove an interface from  a given bridge."""
-    if gateway_nic in list_bridge_ifaces(external_bridge):
-        logging.warning(f"Removing interface {gateway_nic} from {external_bridge}")
-        subprocess.check_call(["ovs-vsctl", "--retry", "del-port", external_bridge, gateway_nic])
+def _del_interface_from_bridge(external_bridge: str, external_nic: str) -> None:
+    """Remove an interface from  a given bridge.
+
+    :param bridge_name: Name of bridge.
+    :param external_nic: Name of nic.
+    """
+    if external_nic in _list_bridge_ifaces(external_bridge):
+        logging.warning(f"Removing interface {external_nic} from {external_bridge}")
+        subprocess.check_call(["ovs-vsctl", "--retry", "del-port", external_bridge, external_nic])
     else:
-        logging.warning(f"Interface {gateway_nic} not connected to {external_bridge}")
+        logging.warning(f"Interface {external_nic} not connected to {external_bridge}")
+
+
+def _get_external_ports_on_bridge(bridge: str) -> list:
+    """Get microstack managed external port on bridge.
+
+    :param bridge_name: Name of bridge.
+    """
+    cmd = [
+        "ovs-vsctl",
+        "-f",
+        "json",
+        "find",
+        "Port",
+        "external-ids:microstack-function=ext-port",
+    ]
+    output = json.loads(subprocess.check_output(cmd))
+    name_idx = output["headings"].index("name")
+    external_nics = [r[name_idx] for r in output["data"]]
+    bridge_ifaces = _list_bridge_ifaces(bridge)
+    return [i for i in bridge_ifaces if i in external_nics]
+
+
+def _ensure_single_nic_on_bridge(external_bridge: str, external_nic: str) -> None:
+    """Ensure nic is attached to bridge and no other microk8s managed nics.
+
+    :param bridge_name: Name of bridge.
+    :param external_nic: Name of nic.
+    """
+    external_ports = _get_external_ports_on_bridge(external_bridge)
+    if external_nic in external_ports:
+        logging.debug(f"{external_nic} already attached to {external_bridge}")
+    else:
+        _add_interface_to_bridge(external_bridge, external_nic)
+    for p in external_ports:
+        if p != external_nic:
+            logging.debug(
+                f"Removing additional extranal ports {external_ports} from {external_bridge}"
+            )
+            _del_interface_from_bridge(external_bridge, p)
+
+
+def _del_external_nics_from_bridge(external_bridge: str) -> None:
+    """Delete all microk8s managed external nics from bridge.
+
+    :param bridge_name: Name of bridge.
+    """
+    for p in _get_external_ports_on_bridge(external_bridge):
+        _del_interface_from_bridge(external_bridge, p)
 
 
 def _configure_ovn_external_networking(snap: Snap) -> None:
@@ -541,9 +612,9 @@ def _configure_ovn_external_networking(snap: Snap) -> None:
     external_bridge = snap.config.get("network.external-bridge")
     physnet_name = snap.config.get("network.physnet-name")
     try:
-        gateway_nic = snap.config.get("network.gateway-nic")
+        external_nic = snap.config.get("network.external-nic")
     except UnknownConfigKey:
-        gateway_nic = None
+        external_nic = None
     if not external_bridge and physnet_name:
         logging.info("OVN external networking not configured, skipping.")
         return
@@ -580,8 +651,12 @@ def _configure_ovn_external_networking(snap: Snap) -> None:
         logging.info(f"Resetting external bridge {external_bridge} configuration")
         _delete_ips_from_interface(external_bridge)
         _delete_iptable_postrouting_rule(comment)
-        if gateway_nic:
-            add_interface_to_bridge(external_bridge, gateway_nic)
+        if external_nic:
+            logging.info(f"Adding {external_nic} to {external_bridge}")
+            _ensure_single_nic_on_bridge(external_bridge, external_nic)
+        else:
+            logging.info(f"Removing nics from {external_bridge}")
+            _del_external_nics_from_bridge(external_bridge)
     else:
         logging.info(f"configuring external bridge {external_bridge}")
         _add_ip_to_interface(external_bridge, external_bridge_address)

--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -80,7 +80,7 @@ class NetworkConfig(BaseModel):
     ovn_cacert: Optional[str] = Field(alias="ovn-cacert")
     enable_gateway: bool = Field(alias="enable-gateway", default=False)
     ip_address: Optional[IPvAnyAddress] = Field(alias="ip-address")
-    gateway_nic: Optional[str] = Field(alias="gateway-nic")
+    external_nic: Optional[str] = Field(alias="external-nic")
 
 
 class NodeConfig(BaseModel):

--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -80,6 +80,7 @@ class NetworkConfig(BaseModel):
     ovn_cacert: Optional[str] = Field(alias="ovn-cacert")
     enable_gateway: bool = Field(alias="enable-gateway", default=False)
     ip_address: Optional[IPvAnyAddress] = Field(alias="ip-address")
+    gateway_nic: Optional[str] = Field(alias="gateway-nic")
 
 
 class NodeConfig(BaseModel):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -59,6 +59,12 @@ def check_call():
 
 
 @pytest.fixture
+def check_output():
+    with patch("subprocess.check_output") as p:
+        yield p
+
+
+@pytest.fixture
 def link_lookup():
     with patch("pyroute2.IPRoute.link_lookup") as p:
         yield p

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
+from unittest import mock
+
 import pytest
 
 from openstack_hypervisor import hooks
@@ -113,25 +116,130 @@ class TestHooks:
 
     def test_list_bridge_ifaces(self, check_output):
         check_output.return_value = b"int1\nint2\n"
-        assert hooks.list_bridge_ifaces("br1") == ["int1", "int2"]
+        assert hooks._list_bridge_ifaces("br1") == ["int1", "int2"]
         check_output.assert_called_once_with(["ovs-vsctl", "--retry", "list-ifaces", "br1"])
 
     def test_add_interface_to_bridge(self, check_call, check_output):
         check_output.return_value = b"int1\nint2\n"
-        hooks.add_interface_to_bridge("br1", "int3")
-        check_call.assert_called_once_with(["ovs-vsctl", "--retry", "add-port", "br1", "int3"])
+        hooks._add_interface_to_bridge("br1", "int3")
+        check_call.assert_called_once_with(
+            [
+                "ovs-vsctl",
+                "--retry",
+                "add-port",
+                "br1",
+                "int3",
+                "--",
+                "set",
+                "Port",
+                "int3",
+                "external-ids:microstack-function=ext-port",
+            ]
+        )
 
     def test_add_interface_to_bridge_noop(self, check_call, check_output):
         check_output.return_value = b"int1\nint2\n"
-        hooks.add_interface_to_bridge("br1", "int2")
+        hooks._add_interface_to_bridge("br1", "int2")
         assert not check_call.called
 
     def test_del_interface_from_bridge(self, check_call, check_output):
         check_output.return_value = b"int1\nint2\n"
-        hooks.del_interface_from_bridge("br1", "int2")
+        hooks._del_interface_from_bridge("br1", "int2")
         check_call.assert_called_once_with(["ovs-vsctl", "--retry", "del-port", "br1", "int2"])
 
     def test_del_interface_from_bridge_noop(self, check_call, check_output):
         check_output.return_value = b"int1\nint2\n"
-        hooks.del_interface_from_bridge("br1", "int3")
+        hooks._del_interface_from_bridge("br1", "int3")
         assert not check_call.called
+
+    def test_get_external_ports_on_bridge(self, check_output, mocker):
+        port_data = {
+            "data": [
+                [
+                    ["uuid", "efd95c01-d658-4847-8506-664eec95e653"],
+                    ["set", []],
+                    0,
+                    False,
+                    ["set", []],
+                    0,
+                    ["set", []],
+                    ["map", [["microk8s-function", "external-nic"]]],
+                    False,
+                    ["uuid", "92f62f7c-53f2-4362-bbd5-9b46b8f88632"],
+                    ["set", []],
+                    ["set", []],
+                    "enp6s0",
+                    ["map", []],
+                    False,
+                    ["set", []],
+                    ["map", []],
+                    ["map", []],
+                    ["map", []],
+                    ["map", []],
+                    ["set", []],
+                    ["set", []],
+                    ["set", []],
+                ]
+            ],
+            "headings": [
+                "_uuid",
+                "bond_active_slave",
+                "bond_downdelay",
+                "bond_fake_iface",
+                "bond_mode",
+                "bond_updelay",
+                "cvlans",
+                "external_ids",
+                "fake_bridge",
+                "interfaces",
+                "lacp",
+                "mac",
+                "name",
+                "other_config",
+                "protected",
+                "qos",
+                "rstp_statistics",
+                "rstp_status",
+                "statistics",
+                "status",
+                "tag",
+                "trunks",
+                "vlan_mode",
+            ],
+        }
+
+        check_output.return_value = str.encode(json.dumps(port_data))
+        mock_list_ifaces = mocker.patch.object(hooks, "_list_bridge_ifaces")
+        mock_list_ifaces.return_value = ["enp6s0"]
+        assert hooks._get_external_ports_on_bridge("br-ex") == ["enp6s0"]
+        mock_list_ifaces.return_value = []
+        assert hooks._get_external_ports_on_bridge("br-ex") == []
+
+    def test_ensure_single_nic_on_bridge(self, mocker):
+        mock_get_external_ports_on_bridge = mocker.patch.object(
+            hooks, "_get_external_ports_on_bridge"
+        )
+        mock_add_interface_to_bridge = mocker.patch.object(hooks, "_add_interface_to_bridge")
+        mock_del_interface_from_bridge = mocker.patch.object(hooks, "_del_interface_from_bridge")
+        mock_get_external_ports_on_bridge.return_value = ["eth0", "eth1"]
+        hooks._ensure_single_nic_on_bridge("br-ex", "eth1")
+        assert not mock_add_interface_to_bridge.called
+        mock_del_interface_from_bridge.assert_called_once_with("br-ex", "eth0")
+
+        mock_get_external_ports_on_bridge.reset_mock()
+        mock_add_interface_to_bridge.reset_mock()
+        mock_del_interface_from_bridge.reset_mock()
+        mock_get_external_ports_on_bridge.return_value = []
+        hooks._ensure_single_nic_on_bridge("br-ex", "eth1")
+        mock_add_interface_to_bridge.assert_called_once_with("br-ex", "eth1")
+        assert not mock_del_interface_from_bridge.called
+
+    def test_del_external_nics_from_bridge(self, mocker):
+        mock_get_external_ports_on_bridge = mocker.patch.object(
+            hooks, "_get_external_ports_on_bridge"
+        )
+        mock_del_interface_from_bridge = mocker.patch.object(hooks, "_del_interface_from_bridge")
+        mock_get_external_ports_on_bridge.return_value = ["eth0", "eth1"]
+        hooks._del_external_nics_from_bridge("br-ex")
+        expect = [mock.call("br-ex", "eth0"), mock.call("br-ex", "eth1")]
+        mock_del_interface_from_bridge.assert_has_calls(expect)


### PR DESCRIPTION
If a nic is supplied for use for north/south traffic then wire it into br-ex. Also manage removing it if /reset is called.