### PR TITLE
Fix pyroute2 compat issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ pydantic
 uvicorn[standard]
 
 # Matched version from focal to ensure snap-helpers correct writes hooks
-pyroute2==0.5.9
+pyroute2==0.5.14

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ environment:
   LC_ALL: C
   PATH: $SNAP/usr/sbin:$SNAP/usr/bin:$SNAP/sbin:$SNAP/bin:$SNAP/usr/local/bin:$SNAP/usr/local/sbin:$PATH
   # Standard library components must have priority in module name resolution: https://storyboard.openstack.org/#!/story/2007806
-  PYTHONPATH: $PYTHONPATH:$SNAP/usr/lib/python3.8:$SNAP/lib/python3.8/site-packages:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.8/site-packages
+  PYTHONPATH: $PYTHONPATH:$SNAP/usr/lib/python3.8:$SNAP/usr/lib/python3/dist-packages:$SNAP/usr/lib/python3.8/site-packages:$SNAP/lib/python3.8/site-packages
   # /usr/lib/$SNAPCRAFT_ARCH_TRIPLET not added to LD_LIBRARY_PATH by default
   # Causes:
   # CVE-2020-27348: A potentially empty LD_LIBRARY_PATH has been set for environment in '.'.


### PR DESCRIPTION
 Ensure that any distro provided packages take priority over any
 directly installed from pypi.
    
 Pin pyroute2 to the focal/xena version (although the UCA package
 also has backports of a new exception class for compatibility
 with Neutron).
