### PR TITLE
Fix file exists error not being detected as error type

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -30,8 +30,8 @@ from typing import Any, Dict, List
 
 from jinja2 import Environment, FileSystemLoader, Template
 from netifaces import AF_INET, gateways, ifaddresses
-from pr2modules.netlink.exceptions import NetlinkError
 from pyroute2 import IPRoute
+from pyroute2.netlink.exceptions import NetlinkError
 from snaphelpers import Snap
 from snaphelpers._conf import UnknownConfigKey
 
@@ -358,7 +358,7 @@ def _add_ip_to_interface(interface: str, cidr: str) -> None:
     try:
         ipr.addr("add", index=dev, address=ip_mask[0], mask=int(ip_mask[1]))
     except NetlinkError as e:
-        if not e.code == errno.EEXIST:
+        if e.code != errno.EEXIST:
             raise e
 
     ipr.link("set", index=dev, state="up")


### PR DESCRIPTION
Use a different import path for the file exists error, and use the different operator to check for the code.