### PR TITLE
Add Service Token support

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -147,12 +147,15 @@ def _get_local_ip_by_default_route() -> str:
 
 DEFAULT_CONFIG = {
     # Keystone
+    "identity.admin-role": "Admin",
     "identity.auth-url": "http://localhost:5000/v3",
     "identity.username": UNSET,
     "identity.password": UNSET,
     # keystone-k8s defaults
+    "identity.user-domain-id": UNSET,
     "identity.user-domain-name": "service_domain",
     "identity.project-name": "services",
+    "identity.project-domain-id": UNSET,
     "identity.project-domain-name": "service_domain",
     "identity.region-name": "RegionOne",
     # Messaging

--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -27,12 +27,17 @@ class RabbitMQUrl(AnyUrl):
 class IdentityServiceConfig(BaseModel):
     """Data Model for Keystone Identity settings for the hypervisor services."""
 
+    admin_role: Optional[str] = Field(alias="admin-role", default="Admin")
     auth_url: Optional[AnyUrl] = Field(alias="auth-url", default=None)
     username: Optional[str]
     password: Optional[str]
     user_domain_name: Optional[str] = Field(
         alias="user-domain-name",
         default="service_domain",
+    )
+    user_domain_id: Optional[str] = Field(
+        alias="user-domain-id",
+        default=None,
     )
     project_name: Optional[str] = Field(
         alias="project-name",
@@ -41,6 +46,10 @@ class IdentityServiceConfig(BaseModel):
     project_domain_name: Optional[str] = Field(
         alias="project-domain-name",
         default="service_domain",
+    )
+    project_domain_id: Optional[str] = Field(
+        alias="project-domain-id",
+        default=None,
     )
     region_name: Optional[str] = Field(
         alias="region-name",

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -71,6 +71,18 @@ user_domain_name = {{ identity.user_domain_name }}
 project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
+service_token_roles = {{ identity.admin_role }}
+service_token_roles_required = True
+
+[service_user]
+send_service_user_token = true
+auth_type = password
+auth_url = {{ identity.auth_url }}
+project_domain_id = {{ identity.project_domain_id }}
+user_domain_id = {{ identity.user_domain_id }}
+project_name = {{ identity.project_name }}
+username = {{ identity.username }}
+password = {{ identity.password }}
 
 [paste_deploy]
 flavor = keystone


### PR DESCRIPTION
As documented in [1] service tokens are useful to prevent issues with long running services or with requests that take a long time to finish where the user token can expire in the middle of an operation.

[1] https://docs.openstack.org/cinder/latest/configuration/block-storage/service-token.html

Depends-On: https://review.opendev.org/c/openstack/charm-keystone-k8s/+/885815