### PR TITLE
Remove dest cidr from iptables rules

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -391,8 +391,6 @@ def _add_iptable_postrouting_rule(cidr: str, comment: str) -> None:
             "POSTROUTING",
             "-s",
             cidr,
-            "-d",
-            cidr,
             "-j",
             "MASQUERADE",
             "-m",


### PR DESCRIPTION
In a deployment using local access an iptables rule is added to manage traffic from br-ex. This patch updates that rule to allow access from within a guest to any subnet rather than restricting it to the local cidr.