### PR TITLE
Use fallback for determining interface for local ip

### DIFF
--- a/openstack_hypervisor/hooks.py
+++ b/openstack_hypervisor/hooks.py
@@ -27,7 +27,7 @@ import stat
 import string
 import subprocess
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from jinja2 import Environment, FileSystemLoader, Template
 from netifaces import AF_INET, gateways, ifaddresses
@@ -130,14 +130,71 @@ def _setup_secrets(snap: Snap) -> None:
             snap.config.set({secret: _generate_secret()})
 
 
+def _get_default_gw_iface_fallback() -> Optional[str]:
+    """Returns the default gateway interface.
+
+    Parses the /proc/net/route table to determine the interface with a default
+    route. The interface with the default route will have a destination of 0x000000,
+    a mask of 0x000000 and will have flags indicating RTF_GATEWAY and RTF_UP.
+
+    :return Optional[str, None]: the name of the interface the default gateway or
+            None if one cannot be found.
+    """
+    # see include/uapi/linux/route.h in kernel source for more explanation
+    RTF_UP = 0x1  # noqa - route is usable
+    RTF_GATEWAY = 0x2  # noqa - destination is a gateway
+
+    iface = None
+    with open("/proc/net/route", "r") as f:
+        contents = [line.strip() for line in f.readlines() if line.strip()]
+
+        entries = []
+        # First line is a header line of the table contents. Note, we skip blank entries
+        # by default there's an extra column due to an extra \t character for the table
+        # contents to line up. This is parsing the /proc/net/route and creating a set of
+        # entries. Each entry is a dict where the keys are table header and the values
+        # are the values in the table rows.
+        header = [col.strip().lower() for col in contents[0].split("\t") if col]
+        for row in contents[1:]:
+            cells = [col.strip() for col in row.split("\t") if col]
+            entries.append(dict(zip(header, cells)))
+
+        def is_up(flags: str) -> bool:
+            return int(flags, 16) & RTF_UP == RTF_UP
+
+        def is_gateway(flags: str) -> bool:
+            return int(flags, 16) & RTF_GATEWAY == RTF_GATEWAY
+
+        # Check each entry to see if it has the default gateway. The default gateway
+        # will have destination and mask set to 0x00, will be up and is noted as a
+        # gateway.
+        for entry in entries:
+            if int(entry.get("destination", 0xFF), 16) != 0:
+                continue
+            if int(entry.get("mask", 0xFF), 16) != 0:
+                continue
+            flags = entry.get("flags", 0x00)
+            if is_up(flags) and is_gateway(flags):
+                iface = entry.get("iface", None)
+                break
+
+    return iface
+
+
 def _get_local_ip_by_default_route() -> str:
     """Get IP address of host associated with default gateway."""
     interface = "lo"
     ip = "127.0.0.1"
 
     # TOCHK: Gathering only IPv4
-    if "default" in gateways():
+    default_gateways = gateways().get("default", {})
+    if default_gateways and AF_INET in default_gateways:
         interface = gateways()["default"][AF_INET][1]
+    else:
+        # There are some cases where netifaces doesn't return the machine's
+        # default gateway, but it does exist. Let's check the /proc/net/route
+        # table to see if we can find the proper gateway.
+        interface = _get_default_gw_iface_fallback() or "lo"
 
     ip_list = ifaddresses(interface)[AF_INET]
     if len(ip_list) > 0 and "addr" in ip_list[0]:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -136,3 +136,37 @@ def vms():
         "vm3": mock_vm("vm3", os_xml, False),
     }
     yield vms
+
+
+@pytest.fixture()
+def ifaddresses():
+    ifaddresses = {
+        "eth1": {
+            17: [{"addr": "00:16:3e:07:ba:1e", "broadcast": "ff:ff:ff:ff:ff:ff"}],
+            2: [
+                {
+                    "addr": "10.177.200.93",
+                    "netmask": "255.255.255.0",
+                    "broadcast": "10.177.200.255",
+                }
+            ],
+            10: [
+                {
+                    "addr": "fe80::216:3eff:fe07:ba1e%enp5s0",
+                    "netmask": "ffff:ffff:ffff:ffff::/64",
+                }
+            ],
+        },
+        "bond1": {
+            17: [{"addr": "00:16:3e:07:ba:1e", "broadcast": "ff:ff:ff:ff:ff:ff"}],
+            10: [
+                {
+                    "addr": "fe80::216:3eff:fe07:ba1e%bond1",
+                    "netmask": "ffff:ffff:ffff:ffff::/64",
+                }
+            ],
+        },
+    }
+    with patch("openstack_hypervisor.hooks.ifaddresses") as p:
+        p.side_effect = lambda nic: ifaddresses.get(nic)
+        yield p


### PR DESCRIPTION
In some cases, the netifaces does not properly detect the default gateway for the node and returns an empty dict. However, there is a default gateway actually set. This adds a fallback path to parse the contents of the /proc/net/route table and determine which interface to use based on which flags are set on the routes.

Closes-Bug: [#2030497](https://bugs.launchpad.net/charm-openstack-hypervisor/+bug/2030497)

Signed-off-by: Billy Olsen <billy.olsen@gmail.com>
(cherry picked from commit 51b2584268320cccc626bf6366f71c1c9f82a622)