### PR TITLE
Add new service ceilometer-agent-compute

### DIFF
--- a/openstack_hypervisor/api.py
+++ b/openstack_hypervisor/api.py
@@ -31,6 +31,7 @@ MAPPING = {
     "network": model.NetworkConfig,
     "node": model.NodeConfig,
     "logging": model.LoggingConfig,
+    "telemetry": model.TelemetryConfig,
 }
 
 
@@ -136,6 +137,12 @@ async def update_node(config: model.NodeConfig):
 async def update_logging(config: model.LoggingConfig):
     """Updates logging section settings."""
     return _update_settings("logging", config)
+
+
+@app.patch("/settings/telemetry")
+async def update_telemetry(config: model.TelemetryConfig):
+    """Updates telemetry section settings."""
+    return _update_settings("telemetry", config)
 
 
 @app.post("/reset")

--- a/openstack_hypervisor/model.py
+++ b/openstack_hypervisor/model.py
@@ -103,3 +103,10 @@ class LoggingConfig(BaseModel):
     """Data model for the logging configuration for the hypervisor."""
 
     debug: bool = Field(default=False)
+
+
+class TelemetryConfig(BaseModel):
+    """Data model for telemetry configuration settings."""
+
+    enable: bool = Field(default=False)
+    publisher_secret: Optional[str] = Field(alias="publisher-secret")

--- a/openstack_hypervisor/services.py
+++ b/openstack_hypervisor/services.py
@@ -35,6 +35,7 @@ class OpenStackService:
 
     conf_files = []
     conf_dirs = []
+    extra_args = []
 
     executable = None
 
@@ -70,6 +71,7 @@ class OpenStackService:
 
         cmd = [str(executable)]
         cmd.extend(args)
+        cmd.extend(self.extra_args)
         completed_process = subprocess.run(cmd)
 
         logging.info(f"Exiting with code {completed_process.returncode}")
@@ -123,6 +125,21 @@ class NeutronOVNMetadataAgentService(OpenStackService):
 
 
 neutron_ovn_metadata_agent = partial(entry_point, NeutronOVNMetadataAgentService)
+
+
+class CeilometerComputeAgentService(OpenStackService):
+    """A python service object used to run the ceilometer-agent-compute daemon."""
+
+    conf_files = [
+        Path("etc/ceilometer/ceilometer.conf"),
+    ]
+    conf_dirs = []
+    extra_args = ["--polling-namespaces", "compute"]
+
+    executable = Path("usr/bin/ceilometer-polling")
+
+
+ceilometer_compute_agent = partial(entry_point, CeilometerComputeAgentService)
 
 
 class OVSDBServerService:

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ console_scripts =
     nova-api-metadata-service = openstack_hypervisor.services:nova_api_metadata
     ovsdb-server-service = openstack_hypervisor.services:ovsdb_server
     neutron-ovn-metadata-agent-service = openstack_hypervisor.services:neutron_ovn_metadata_agent
+    ceilometer-compute-agent-service = openstack_hypervisor.services:ceilometer_compute_agent
 
 snaphelpers.hooks =
     configure = openstack_hypervisor.hooks:configure

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -233,6 +233,16 @@ apps:
       - firewall-control
       - microstack-support
 
+  ceilometer-compute-agent:
+    command: 'bin/ceilometer-compute-agent-service'
+    after: [libvirtd]
+    daemon: simple
+    plugs:
+      - network
+      - network-bind
+      - firewall-control
+      - microstack-support
+
   hypervisor-config-service:
     command: 'bin/gunicorn openstack_hypervisor.api:app --workers 1 --worker-class uvicorn.workers.UvicornWorker --timeout 120 --bind unix:$SNAP_DATA/run/hypervisor-config/unix.socket'
     restart-condition: on-failure
@@ -540,6 +550,7 @@ parts:
   openstack:
     plugin: nil
     stage-packages:
+      - ceilometer-agent-compute
       - python3-nova
       - python3-neutron
       - python3-os-vif

--- a/templates/ceilometer.conf.j2
+++ b/templates/ceilometer.conf.j2
@@ -1,0 +1,52 @@
+# THIS FILE IS MANAGED BY THE SNAP - CHANGES WILL BE OVERWRITTEN
+# Use $SNAP_COMMON/etc/ceilometer/ceilometer.conf.d for deployment specific
+# configuration
+[DEFAULT]
+debug = {{ logging.debug }}
+
+# AMQP connection to RabbitMQ
+transport_url = {{ rabbitmq.url }}
+
+[polling]
+batch_size = 50
+cfg_file = {{ snap_common }}/etc/ceilometer/polling.yaml
+pollsters_definitions_dirs = {{ snap_common }}/etc/ceilometer/pollsters.d
+
+{% if telemetry.publisher_secret -%}
+[publisher]
+telemetry_secret = {{ telemetry.publisher_secret }}
+{%- endif %}
+
+[gnocchi]
+filter_service_activity = False
+archive_policy = low
+
+[keystone_authtoken]
+auth_url = {{ identity.auth_url }}
+auth_type = password
+project_domain_name = {{ identity.project_domain_name }}
+user_domain_name = {{ identity.user_domain_name }}
+project_name = {{ identity.project_name }}
+username = {{ identity.username }}
+password = {{ identity.password }}
+service_token_roles = {{ identity.admin_role }}
+service_token_roles_required = True
+
+[service_user]
+send_service_user_token = true
+auth_type = password
+auth_url = {{ identity.auth_url }}
+project_domain_id = {{ identity.project_domain_id }}
+user_domain_id = {{ identity.user_domain_id }}
+project_name = {{ identity.project_name }}
+username = {{ identity.username }}
+password = {{ identity.password }}
+
+[service_credentials]
+auth_type = password
+auth_url = {{ identity.auth_url }}
+project_domain_id = {{ identity.project_domain_id }}
+user_domain_id = {{ identity.user_domain_id }}
+project_name = {{ identity.project_name }}
+username = {{ identity.username }}
+password = {{ identity.password }}

--- a/templates/nova.conf.j2
+++ b/templates/nova.conf.j2
@@ -108,3 +108,8 @@ region_name = {{ identity.region_name }}
 project_name = {{ identity.project_name }}
 username = {{ identity.username }}
 password = {{ identity.password }}
+
++{% if telemetry.enable -%}
++[oslo_messaging_notifications]
++driver = messagingv2
++{%- endif %}

--- a/templates/polling.yaml.j2
+++ b/templates/polling.yaml.j2
@@ -1,0 +1,19 @@
+# THIS FILE IS MANAGED BY THE SNAP - CHANGES WILL BE OVERWRITTEN
+{% if telemetry.enable -%}
+---
+sources:
+    - name: some_pollsters
+      interval: 300
+      meters:
+        - cpu
+        - cpu_l3_cache
+        - memory.usage
+        - network.incoming.bytes
+        - network.incoming.packets
+        - network.outgoing.bytes
+        - network.outgoing.packets
+        - disk.device.read.bytes
+        - disk.device.read.requests
+        - disk.device.write.bytes
+        - disk.device.write.requests
+{%- endif %}

--- a/tests/unit/test_hooks.py
+++ b/tests/unit/test_hooks.py
@@ -134,6 +134,7 @@ class TestHooks:
     def test_services(self):
         """Test getting a list of managed services."""
         assert hooks.services() == [
+            "ceilometer-compute-agent",
             "libvirtd",
             "neutron-ovn-metadata-agent",
             "nova-api-metadata",
@@ -162,12 +163,14 @@ class TestHooks:
     def test_services_not_ready(self, snap):
         config = {}
         assert hooks._services_not_ready(config) == [
+            "ceilometer-compute-agent",
             "neutron-ovn-metadata-agent",
             "nova-api-metadata",
             "nova-compute",
         ]
         config["identity"] = {"username": "user", "password": "pass"}
         assert hooks._services_not_ready(config) == [
+            "ceilometer-compute-agent",
             "neutron-ovn-metadata-agent",
             "nova-api-metadata",
             "nova-compute",
@@ -187,6 +190,14 @@ class TestHooks:
         assert hooks._services_not_ready(config) == ["neutron-ovn-metadata-agent"]
         config["credentials"] = {"ovn_metadata_proxy_shared_secret": "secret"}
         assert hooks._services_not_ready(config) == []
+
+    def test_services_not_enabled_by_config(self, snap):
+        config = {}
+        assert hooks._services_not_enabled_by_config(config) == [
+            "ceilometer-compute-agent",
+        ]
+        config["telemetry"] = {"enable": True}
+        assert hooks._services_not_enabled_by_config(config) == []
 
     def test_list_bridge_ifaces(self, check_output):
         check_output.return_value = b"int1\nint2\n"


### PR DESCRIPTION
Add new service to run ceilometer agent polling
for compute node.
Add ceilometer configuration and polling template files. Add config to enable/disable the service and telemetry publish secret key.